### PR TITLE
Properly find JNI headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ set(CMAKE_DISABLE_TESTING ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_BINARY_DIR}>)
 
-include_directories($ENV{JAVA_HOME}/include)
-include_directories($ENV{JAVA_HOME}/include/win32)
-link_directories($ENV{JAVA_HOME}/lib)
+find_package(JNI REQUIRED)
+
+include_directories(${JNI_INCLUDE_DIRS})
 
 include_directories(loader/include)
 
@@ -32,7 +32,7 @@ target_include_directories(loader PUBLIC
 )
 
 target_link_libraries(loader PUBLIC -static
-    Jvm
+    ${JNI_LIBRARIES}
 )
 
 add_executable(inject


### PR DESCRIPTION
# Description

Fixed finding JNI headers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Builds properly using CMake.

# Checklist:

- [x] I have read the [Contribution Guidelines](https://github.com/sbplat/Minecraft-Client-Base/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/sbplat/Minecraft-Client-Base/blob/main/CODE_OF_CONDUCT.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
